### PR TITLE
Pin to latest version of django 1.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # core
-Django==1.5.5
+Django<1.6
 Pillow
 South
 requests


### PR DESCRIPTION
Just a suggestion, so that users get the latest django security release (currently 1.5.9).
