### PR TITLE
Improve description text rendering

### DIFF
--- a/pinry/static/css/pinry.css
+++ b/pinry/static/css/pinry.css
@@ -243,6 +243,8 @@ textarea {
     font-size: 12px;
     margin-bottom: 0;
     padding: 8px;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .pin strong {

--- a/pinry/static/js/helpers.js
+++ b/pinry/static/js/helpers.js
@@ -58,3 +58,15 @@ function postPinData(data) {
 function getUrlParameter(name) {
     return decodeURIComponent((new RegExp('[?|&]' + name + '=' + '([^&;]+?)(&|#|;|$)').exec(location.search)||[,""])[1].replace(/\+/g, '%20'))||null;
 }
+
+Handlebars.registerHelper('niceLinks', (function () {
+    var reNL = /\r?\n/g,
+        reURL = /https?:[/][/](?:www[.])?([^/]+)(?:[/]([.]?[^\s,.])+)?/g;
+    return function (text) {
+        var t = Handlebars.Utils.escapeExpression(text);
+        t = t.replace(reURL, '<a href="$&" target="_blank">$1</a>');
+        t = t.replace(reNL, '<br>');
+        return new Handlebars.SafeString(t);
+    };
+})());
+

--- a/pinry/templates/includes/lightbox.html
+++ b/pinry/templates/includes/lightbox.html
@@ -8,7 +8,7 @@
                 <div class="lightbox-data clearfix">
                 {{#if description}}
                     <div class="description">
-                        {{description}}
+                        {{niceLinks description}}
                     </div>
                 {{/if}}
                     <div class="avatar pull-left">

--- a/pinry/templates/includes/pins.html
+++ b/pinry/templates/includes/pins.html
@@ -18,7 +18,7 @@
                 </div>
             </a>
             {{#if description}}
-                <p>{{description}}</p>
+                <p>{{niceLinks description}}</p>
             {{/if}}
             <div class="pin-footer clearfix">
                 <div class="avatar pull-left">


### PR DESCRIPTION
This might vary depending on personal preferences, but I decided to honor newlines and to shorten links to show only the domain.
(I usually use text to signal the source website, it started as a work around for #59 but sometime I use more than one url-reference)