### PR TITLE
Remove race condition waiting for proper event instead of fixed time

### DIFF
--- a/pinry/static/js/pin-form.js
+++ b/pinry/static/js/pin-form.js
@@ -48,9 +48,9 @@ $(window).load(function() {
 
     function dismissModal(modal) {
         modal.modal('hide');
-        setTimeout(function() {
+        modal.on('hidden.bs.modal', function() {
             modal.remove();
-        }, 200);
+        });
     }
     // End Helper Functions
 


### PR DESCRIPTION
Sometimes after I cancel an edit the pin list does not scroll anymore, or some other times the gray backdrops doesn't get deleted. After this change I didn't have the problem anymore.
