### PR TITLE
Fix N+1 queries in pin loading

### DIFF
--- a/pinry/core/api.py
+++ b/pinry/core/api.py
@@ -139,7 +139,7 @@ class PinResource(ModelResource):
         filtering = {
             'submitter': ALL_WITH_RELATIONS
         }
-        queryset = Pin.objects.all().select_related('submitter'). \
+        queryset = Pin.objects.all().select_related('submitter', 'image'). \
             prefetch_related('image__thumbnail_set', 'tags')
         resource_name = 'pin'
         include_resource_uri = False

--- a/pinry/core/api.py
+++ b/pinry/core/api.py
@@ -60,10 +60,13 @@ class UserResource(ModelResource):
 
 def filter_generator_for(size):
     def wrapped_func(bundle, **kwargs):
-        for thumbnail in bundle.obj._prefetched_objects_cache['thumbnail']:
-            if thumbnail.size == size:
-                return thumbnail
-        raise ObjectDoesNotExist()
+        if hasattr(bundle.obj, '_prefetched_objects_cache') and 'thumbnail' in bundle.obj._prefetched_objects_cache:
+            for thumbnail in bundle.obj._prefetched_objects_cache['thumbnail']:
+                if thumbnail.size == size:
+                    return thumbnail
+            raise ObjectDoesNotExist()
+        else:
+            return bundle.obj.get_by_size(size)
     return wrapped_func
 
 

--- a/pinry/core/api.py
+++ b/pinry/core/api.py
@@ -135,7 +135,8 @@ class PinResource(ModelResource):
         filtering = {
             'submitter': ALL_WITH_RELATIONS
         }
-        queryset = Pin.objects.all()
+        queryset = Pin.objects.all().select_related('submitter'). \
+            prefetch_related('image', 'tags')
         resource_name = 'pin'
         include_resource_uri = False
         always_return_data = True

--- a/pinry/core/api.py
+++ b/pinry/core/api.py
@@ -63,7 +63,7 @@ def filter_generator_for(size):
         for thumbnail in bundle.obj._prefetched_objects_cache['thumbnail']:
             if thumbnail.size == size:
                 return thumbnail
-        raise DoesNotExist()
+        raise ObjectDoesNotExist()
     return wrapped_func
 
 


### PR DESCRIPTION
Fetch the submitter with a join and get all the images, thumbnails and tags in one query each. This reduces the total query count for loading 50 pins from 304 to 8 and saves roughly half the time on my machine.

See issue #85 .