### PR TITLE
remove explicit http image for gravatar images

### DIFF
--- a/pinry/templates/includes/lightbox.html
+++ b/pinry/templates/includes/lightbox.html
@@ -12,7 +12,7 @@
                     </div>
                 {{/if}}
                     <div class="avatar pull-left">
-                        <img src="http://gravatar.com/avatar/{{submitter.gravatar}}.jpg">
+                        <img src="//gravatar.com/avatar/{{submitter.gravatar}}.jpg">
                     </div>
                     <div class="text pull-left">
                         <span class="dim">pinned by</span> {{submitter.username}}

--- a/pinry/templates/includes/pins.html
+++ b/pinry/templates/includes/pins.html
@@ -22,7 +22,7 @@
             {{/if}}
             <div class="pin-footer clearfix">
                 <div class="avatar pull-left">
-                    <img src="http://gravatar.com/avatar/{{submitter.gravatar}}">
+                    <img src="//gravatar.com/avatar/{{submitter.gravatar}}">
                 </div>
                 <div class="text pull-right">
                     <span class="dim">pinned by</span>


### PR DESCRIPTION
When hosted on a https site (for example using nginx with reverse proxy), the site appeared "https unsafe" as it contains on each page displaying gravatar images a http link which produce a "http+https mixed content".

As gravatar support both http and https, it's better to just include image with source like "//gravatar.com/..." because it will choose http or https depending of the current protocol used for the page.
