### PR TITLE
Add Travis CI test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+
+python:
+  - "2.7"
+
+install:
+  - pip install -r requirements.txt
+
+script:
+  - python manage.py test


### PR DESCRIPTION
This patch enables to test on Travis CI.
To enable it, we need to do follow steps.

Step 1: Sign in to https://travis-ci.org/ with GitHub account.
Step 2: Sync account.
Step 3: Activate pinry/pinry.