### PR TITLE
Fix tags being serialized as stringified map objects

### DIFF
--- a/core/api.py
+++ b/core/api.py
@@ -122,7 +122,7 @@ class PinResource(ModelResource):
         return bundle
 
     def dehydrate_tags(self, bundle):
-        return map(str, bundle.obj.tags.all())
+        return list(map(str, bundle.obj.tags.all()))
 
     def build_filters(self, filters=None):
         orm_filters = super(PinResource, self).build_filters(filters)


### PR DESCRIPTION
This fixes an issue where the `tags` key of pins in the API response would be serialized as the string `"<map object at 0x...>". This issue would cause a `TypeError: pins.objects[i].tags.sort is not a function` on the frontend and prevent the page from loading.