### PR TITLE
Feature: Use page title as default description

### DIFF
--- a/pinry/static/js/bookmarklet.js
+++ b/pinry/static/js/bookmarklet.js
@@ -94,6 +94,7 @@
         image.onclick = function() {
             var popUrl = getFormUrl() + encodeURIComponent(imageUrl);
             popUrl = popUrl + '&referer=' + encodeURIComponent(window.location);
+            popUrl = popUrl + '&description=' + encodeURIComponent(document.title);
             window.open(popUrl);
             closePinry();
         };

--- a/pinry/static/js/pin-form.js
+++ b/pinry/static/js/pin-form.js
@@ -68,6 +68,7 @@ $(window).load(function() {
               $('#pin-form-tags')
             ],
             pinFromUrl = getUrlParameter('pin-image-url'),
+            pinFromDescription = getUrlParameter('description'),
             pinFromReferer = getUrlParameter('referer');
         // If editable grab existing data
         if (editPinId) {
@@ -122,6 +123,7 @@ $(window).load(function() {
             $('#pin-form-image-upload').parent().css('display', 'none');
             $('#pin-form-image-url').val(pinFromUrl);
             $('#pin-form-referer').val(pinFromReferer);
+            $('#pin-form-description').val(pinFromDescription);
             $('.navbar').css('display', 'none');
             modal.css({
                 'margin-top': -35,


### PR DESCRIPTION
A simple feauture, works well with all version of pinry.

![image](https://user-images.githubusercontent.com/4109722/44625898-7e346280-a945-11e8-9aae-eb4c4ac1a922.png)


http://192.168.200.147:8000/pins/pin-form/?pin-image-url=https%3A%2F%2Fcdnb.artstation.com%2Fp%2Fassets%2Fimages%2Fimages%2F012%2F470%2F763%2Flarge%2Fdavid-noren-hillbillygys2.jpg%3F1534957770&referer=https%3A%2F%2Fwww.artstation.com%2Fartwork%2Fmrraa&description=ArtStation%20-%20Old%20northern%20rail%20station%2C%20David%20Noren