### PR TITLE
remove reference to demo from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ The open-source core of Pinry, a tiling image board system for people
 who want to save, tag, and share images, videos and webpages in an easy
 to skim through format.
 
-For more information and a working demo board visit `getpinry.com`_.
+For more information visit `getpinry.com`_.
 
 Feature
 -----------------


### PR DESCRIPTION
This removes the reference to a demo on getpinry.com, at least until there is a working demo there.