### PR TITLE
Try to optimize Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.gitignore
+.dockerignore
+Dockerfile*
+.flake8
+.travis.yml
+doc

--- a/Dockerfile.autobuild
+++ b/Dockerfile.autobuild
@@ -14,31 +14,45 @@
 # Base system is the LTS version of Ubuntu.
 FROM python:3.6-stretch
 
-RUN groupadd -g 2300 tmpgroup && usermod -g tmpgroup www-data && groupdel www-data && groupadd -g 1000 www-data && usermod -g www-data www-data && usermod -u 1000 www-data && groupdel tmpgroup
+RUN groupadd -g 2300 tmpgroup \
+ && usermod -g tmpgroup www-data \
+ && groupdel www-data \
+ && groupadd -g 1000 www-data \
+ && usermod -g www-data www-data \
+ && usermod -u 1000 www-data \
+ && groupdel tmpgroup \
+#
+ && mkdir -p /srv/www/pinry/logs \
+#
+ && mkdir /data \
+ && chown -R www-data:www-data /data \
+#
+ && mkdir -p /var/log/gunicorn \
+ && apt-get update \
+    && apt-get -y install nginx nginx-extras pwgen \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN apt-get update
-RUN apt-get -y install nginx nginx-extras pwgen
+RUN pip --no-cache-dir install pipenv gunicorn
 
-RUN mkdir -p /srv/www/; cd /srv/www/; git clone https://github.com/pinry/pinry.git
-RUN mkdir /srv/www/pinry/logs; mkdir /data
-RUN cd /srv/www/pinry && pip install pipenv && pipenv install --three --system
-RUN pip install gunicorn
+COPY Pipfile* /srv/www/pinry/
+
+RUN cd /srv/www/pinry \
+ && pipenv install --three --system --clear
+
+COPY . /srv/www/pinry/
 
 # Fix permissions
-RUN chown -R www-data:www-data /srv/www
-
+RUN chown -R www-data:www-data /srv/www \
+ && cd /srv/www/pinry \
+ && python manage.py collectstatic --noinput
+ 
 
 # Load in all of our config files.
-ADD docker-contents/nginx/nginx.conf /etc/nginx/nginx.conf
-ADD docker-contents/nginx/sites-enabled/default /etc/nginx/sites-enabled/default
-
-# Fix permissions
-RUN mkdir /scripts/
-ADD docker-contents/scripts/* /scripts/
-RUN chown -R www-data:www-data /data
-RUN mkdir /var/log/gunicorn
+ADD docker/nginx/nginx.conf /etc/nginx/nginx.conf
+ADD docker/nginx/sites-enabled/default /etc/nginx/sites-enabled/default
+ADD docker/scripts/* /scripts/
 
 # 80 is for nginx web, /data contains static files and database /start runs it.
-expose 80
-volume ["/data"]
-cmd    ["/scripts/start.sh"]
+EXPOSE 80
+VOLUME ["/data"]
+CMD    ["/scripts/start.sh"]


### PR DESCRIPTION
Here is a summary of modification on the Dockerfile.autobuild, which is copied from docker-pinry repository:
1. Reduce image layers 
  a. by merge RUN commands as much as possible with `&&`
2. Reduce image size
  a. clean up apt package list after install required packages by `rm -rf /var/lib/apt/lists/*`
  b. run `pip install` with `--no-cache-dir`
  c. run `pipenv install` with `--clear`
3. Make better use of docker build cache
  a. copy the Pipfile* files first so `pipenv install` could be cached
  a. move more frequently changed steps later in the Dockerfile, e.g. copying the source code
4. Reduce container provision time by doing collectstatic during image build