### PR TITLE
Use Django's standard field rendering for User forms.

### DIFF
--- a/core/templatetags/bootstrap_field.py
+++ b/core/templatetags/bootstrap_field.py
@@ -1,7 +1,8 @@
 from django.template import Library
- 
+
 register = Library()
- 
+
+
 @register.filter(name='bootstrap_field')
 def bootstrap_field(field, class_attr):
     return field.as_widget(attrs={

--- a/core/templatetags/bootstrap_field.py
+++ b/core/templatetags/bootstrap_field.py
@@ -1,10 +1,10 @@
-from django.template import loader, Context, Library
-
-
+from django.template import Library
+ 
 register = Library()
-
-
-@register.simple_tag
-def bootstrap_field(field):
-    template = loader.get_template('core/templatetags/bootstrap_field.html')
-    return template.render(Context({'field': field}))
+ 
+@register.filter(name='bootstrap_field')
+def bootstrap_field(field, class_attr):
+    return field.as_widget(attrs={
+        'placeholder': field.label,
+        'class': class_attr
+    })

--- a/pinry/templates/includes/field.html
+++ b/pinry/templates/includes/field.html
@@ -1,5 +1,7 @@
+{% load bootstrap_field %}
+
 <div class="form-group{% if field.errors %} has-error{% endif %}">
-    <input type="{% if field.html_name == "password" %}password{% else %}text{% endif %}" id="id_{{ field.html_name }}" name="{{ field.html_name }}" class="form-control input-lg" placeholder="{{ field.label }}"/>
+    {{ field|bootstrap_field:"form-control input-lg" }}
     {% if field.errors %}
         <span class="help-block">
             {% if field.errors %}


### PR DESCRIPTION
Django has some nice details in the way it renders form fields, specifically retaining the previously entered values if there's an error.

Instead of replacing field.render() with a template I've used the `attrs` argument to that method to perform the styling we need via a template filter.