### PR TITLE
Fix: Remove 3.5 support since library "black" doesn't support it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ language: python
 cache:
     pip: true
 python:
-    - "3.5"
     - "3.6"
+    - "3.7"
+    - "3.8"
 install:
     - pip install pipenv && pipenv install --dev --system
 script:


### PR DESCRIPTION
Try to add 3.7 and 3.8 as test version

This page shows that travis support 3.7 and 3.8 https://docs.travis-ci.com/user/languages/python/