### PR TITLE
Convert Dockerfile to Multi-Stage & Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ docker-compose.yml
 
 # vscode
 /.vscode
+
+# docker image data
+docker/data/*

--- a/Dockerfile.autobuild
+++ b/Dockerfile.autobuild
@@ -44,7 +44,7 @@ RUN groupadd -g 2300 tmpgroup \
 
 # Install nginx
 RUN apt-get update \
-    && apt-get -y  install nginx \
+    && apt-get -y  install nginx pwgen\
     && rm -rf /var/lib/apt/lists/* \
     && apt-get autoclean
 

--- a/Dockerfile.autobuild
+++ b/Dockerfile.autobuild
@@ -5,13 +5,34 @@
 # all of it's assets, there are more optimal ways to do this but this is the
 # most friendly and has everything contained in a single instance.
 #
-# Authors: Isaac Bythewood
-# Updated: Mar 29th, 2016
+# Authors: Isaac Bythewood, Jason Kaltsikis
+# Updated: May 2nd, 2020
 # Require: Docker (http://www.docker.io/)
 # -----------------------------------------------------------------------------
 
-# Base system is the LTS version of Ubuntu.
-FROM python:3.7-stretch
+# Build static yarn file
+FROM node:10.20.1-alpine3.11 as yarn-build
+
+WORKDIR pinry-spa
+COPY pinry-spa/package.json .
+RUN yarn install
+COPY pinry-spa .
+RUN yarn build
+
+
+# Required for other database options
+FROM python:3.7-slim-stretch as base
+
+RUN apt-get update \
+    && apt-get -y install gcc default-libmysqlclient-dev
+RUN pip --no-cache-dir install --user mysqlclient cx-Oracle
+
+
+# Final image
+FROM python:3.7-slim-stretch
+
+WORKDIR pinry
+RUN mkdir /data && chown -R www-data:www-data /data
 
 RUN groupadd -g 2300 tmpgroup \
  && usermod -g tmpgroup www-data \
@@ -21,30 +42,24 @@ RUN groupadd -g 2300 tmpgroup \
  && usermod -u 1000 www-data \
  && groupdel tmpgroup
 
-RUN mkdir /data
-RUN chown -R www-data:www-data /data
-
+# Install nginx
 RUN apt-get update \
-    && apt-get -y install nginx nginx-extras pwgen \
+    && apt-get -y  install nginx \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get autoclean
 
-# required for other database options
-RUN pip --no-cache-dir install pipenv gunicorn mysqlclient psycopg2 cx-Oracle
+# Install Pipfile requirements
+COPY Pipfile* ./
+RUN pip install rcssmin --install-option="--without-c-extensions" \
+    && pip install pipenv \
+    && pipenv install --three --system --clear
 
-# COPY and start installation
-COPY . /pinry
+# Copy from previous stages
+COPY --from=yarn-build pinry-spa/dist /pinry/pinry-spa/dist
+COPY --from=base /root/.local /root/.local
+ENV PATH=/root/.local/bin:$PATH
 
-RUN cd /pinry \
- && pipenv install --three --system --clear
-
-# config nodejs
-RUN curl -L https://raw.githubusercontent.com/tj/n/master/bin/n -o n || exit
-RUN bash n 10
-RUN npm -g install yarn
-
-# build frontend
-RUN cd /pinry/pinry-spa/ && yarn install && yarn build
+COPY . .
 
 # Load in all of our config files.
 ADD docker/nginx/nginx.conf /etc/nginx/nginx.conf

--- a/Dockerfile.autobuild
+++ b/Dockerfile.autobuild
@@ -14,7 +14,7 @@
 FROM node:10.20.1-alpine3.11 as yarn-build
 
 WORKDIR pinry-spa
-COPY pinry-spa/package.json .
+COPY pinry-spa/package.json pinry-spa/yarn.lock ./
 RUN yarn install
 COPY pinry-spa .
 RUN yarn build


### PR DESCRIPTION
This pull request introduces the following changes:
- Decrease Dockefile image from 1.46GB to 325MB. 
1.  Leveraging Docker Multi-Stage technique
2.  python:3.7-slim-stretch as final image
- Add Docker Data directory to gitignore