### PR TITLE
Add support for links in description

### DIFF
--- a/pinry-spa/src/components/Pins.vue
+++ b/pinry-spa/src/components/Pins.vue
@@ -36,8 +36,7 @@
                      class="pin-preview-image">
                 </div>
                 <div class="pin-footer">
-                  <div class="description" v-show="item.description"><p>{{ item.description }}</p>
-                  </div>
+                  <div class="description" v-show="item.description" v-html="niceLinks(item.description)"></div>
                   <div class="details">
                     <div class="is-pulled-left">
                       <img class="avatar" :src="item.avatar" alt="">
@@ -125,6 +124,18 @@ function initialData() {
       },
     },
   };
+}
+
+const encoder = document.createElement('div');
+function escapeHTML(text) {
+  encoder.innerText = text;
+  return encoder.innerHTML;
+}
+
+const reURL = /https?:[/][/](?:www[.])?([^/]+)(?:[/]([.]?[^\s,.<>])+)?/g;
+function niceLinks(text) {
+  if (!text) return '';
+  return escapeHTML(text).replace(reURL, '<a href="$&" target="_blank">$1</a>');
 }
 
 export default {
@@ -293,6 +304,7 @@ export default {
         () => { this.status.loading = false; },
       );
     },
+    niceLinks,
   },
   created() {
     bus.bus.$on(bus.events.refreshPin, this.reset);


### PR DESCRIPTION
I originally used this patch locally for lack of "Referer" support in old Pinry, now that we have that most of my "single-link descriptions" are obsolete and should be better converted to a "Referer", but I think this can still be an useful feature to have, in case one has more than one link.

E.g. the following description:

> Monika from Doki Doki Literature Club
> https://twitter.com/lilmonix3/status/963869736596467714
> https://satchely.deviantart.com/art/Valentine-s-Monika-730977965

shows up like this:

![image](https://user-images.githubusercontent.com/420454/85324859-e49b5500-b4ca-11ea-8c59-73b8460dd98d.png)

PS: it uses `v-html` but no user-generated HTML is allowed in the description, it gets escaped properly.