### PR TITLE
Set client_max_body_size 50M; to allow file uploads larger than 1m in…

### DIFF
--- a/docker/nginx/sites-enabled/default
+++ b/docker/nginx/sites-enabled/default
@@ -7,6 +7,7 @@ server {
 
     root /pinry/pinry-spa/dist/;
 
+    client_max_body_size 50M;
     location /static {
         alias /data/static;
         expires max;


### PR DESCRIPTION
… Docker hosted instances.