### PR TITLE
Update docker image name

### DIFF
--- a/docs/src/install-with-docker.md
+++ b/docs/src/install-with-docker.md
@@ -23,7 +23,7 @@ DATA_PATH=/abs/path/to/your/data/directory
 
 sudo docker run -d=true -p=80:80 \
     -v=${DATA_PATH}:/data \
-    pinry/pinry
+    getpinry/pinry
 ```
 
 # Build Docker from Source


### PR DESCRIPTION
In docker run command, pinry/pinry is a 3 year old image. Should be getpinry/pinry.