### PR TITLE
docs: fix simple typo, requries -> requires

### DIFF
--- a/docs/src/passwords.md
+++ b/docs/src/passwords.md
@@ -1,7 +1,7 @@
 # Updating Passwords
 
 Currently we don't have a good "forgot my password" method on Pinry since that
-generally requries an email to be sent. The current method for changing
+generally requires an email to be sent. The current method for changing
 passwords involves:
 
 - Create a new super user `pipenv run python manage.py createsuperuser`


### PR DESCRIPTION
There is a small typo in docs/src/passwords.md.

Should read `requires` rather than `requries`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md