### PR TITLE
PinPreview: reword 'pin link' => 'permalink'

### DIFF
--- a/pinry-spa/src/components/PinPreview.vue
+++ b/pinry-spa/src/components/PinPreview.vue
@@ -48,7 +48,7 @@
                       @click="closeAndGoTo"
                       class="meta-link"
                       type="is-success">
-                      Goto Pin Link
+                      Permalink
                   </b-button>
                 </div>
               </div>


### PR DESCRIPTION
'Permalink' is shorter, and pretty universally recognized.