### PR TITLE
Fix bookmarklet layout to work on more pages.

### DIFF
--- a/pinry/static/js/bookmarklet.js
+++ b/pinry/static/js/bookmarklet.js
@@ -38,7 +38,8 @@
         pinryImages.id = 'pinry-images';
         setCSS(pinryImages, {
             position: 'fixed',
-            zIndex: 9001,
+            display: 'block',
+            zIndex: 2147483647,
             background: 'rgba(0, 0, 0, 0.7)',
             paddingTop: '70px',
             top: 0,
@@ -52,6 +53,7 @@
         var pinryBar = document.createElement('div');
         pinryBar.id = 'pinry-bar';
         setCSS(pinryBar, {
+            display: 'block',
             background: 'black',
             padding: '15px',
             position: 'absolute',


### PR DESCRIPTION
`display: block` is needed on some pages that have local CSS overrides that happen to apply to our elements as well.
`z-index: 2147483647` seems to be the maximum allowed values, as per http://web.archive.org/web/20160502062529/http://www.puidokas.com/max-z-index

Fixes #273.