### PR TITLE
Make Dockerfile.autobuild compatible with arm

### DIFF
--- a/Dockerfile.autobuild
+++ b/Dockerfile.autobuild
@@ -21,7 +21,7 @@ RUN yarn build
 
 
 # Required for other database options
-FROM python:3.7-slim-buster as base
+FROM python:3.9.12-slim-buster as base
 
 RUN apt-get update \
     && apt-get -y install gcc default-libmysqlclient-dev
@@ -29,7 +29,7 @@ RUN pip --no-cache-dir install --user mysqlclient cx-Oracle
 
 
 # Final image
-FROM python:3.7-slim-buster
+FROM python:3.9.12-slim-buster
 
 WORKDIR pinry
 RUN mkdir /data && chown -R www-data:www-data /data

--- a/Dockerfile.autobuild
+++ b/Dockerfile.autobuild
@@ -42,11 +42,13 @@ RUN groupadd -g 2300 tmpgroup \
  && usermod -u 1000 www-data \
  && groupdel tmpgroup
 
-# Install nginx
 RUN apt-get update \
+    # Install nginx
     && apt-get -y  install nginx pwgen \
     # Install Pillow dependencies
     && apt-get -y install libopenjp2-7 libjpeg-turbo-progs libjpeg62-turbo-dev libtiff5-dev libxcb1 \
+    # Needed to compile psycopg2 on arm (fallback for psycopg2-binary)
+    && if [ $(dpkg --print-architecture) = "arm64" -o $(dpkg --print-architecture) = "armhf" ]; then apt-get -y install libpq-dev gcc; fi \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get autoclean
 


### PR DESCRIPTION
This makes `Dockerfile.autobuild` work on arm64 (and probably armhf, but I haven't tested). I have this running on an arm64 Pi4 with these changes.

`psycopg2-binary` isn't available on arm but will fall back to compiling from source so long as those missing libs are installed first. Otherwise it just breaks with "pg_config executable not found" (seems this happened since #248).

I figure if someone else like me wants an arm version they're likely to rebuild [getpinry/pinry](https://hub.docker.com/r/getpinry/pinry/) from the same Dockerfile and will benefit from this.

Hopefully this change makes sense here, rather than a separate Dockerfile; there's probably only a few steps between this and actually publishing a multiarch image to Docker Hub (or just a separate arm tagged image).