### PR TITLE
Don't zoom small images in preview window

### DIFF
--- a/pinry-spa/src/components/PinPreview.vue
+++ b/pinry-spa/src/components/PinPreview.vue
@@ -23,9 +23,7 @@
                   <p class="subtitle is-6" v-show="pinItem.tags.length > 0">
                     <span class="subtitle dim">in&nbsp;</span>
                     <template v-for="tag in pinItem.tags">
-                      <b-tag v-bind:key="tag" type="is-info" class="pin-preview-tag">
-                      <router-link class="pin-preview-tag" :to="{ name: 'tag', params: {tag: tag} }">{{ tag }}</router-link>
-                      </b-tag>
+                      <b-button v-bind:key="tag" @click="closeAndGoTo" class="pin-preview-image" type="is-link is-small" :to="{ name: 'tag', params: {tag: tag} }">{{ tag }}</b-button>
                     </template>
                   </p>
                 </div>

--- a/pinry-spa/src/components/PinPreview.vue
+++ b/pinry-spa/src/components/PinPreview.vue
@@ -23,7 +23,7 @@
                   <p class="subtitle is-6" v-show="pinItem.tags.length > 0">
                     <span class="subtitle dim">in&nbsp;</span>
                     <template v-for="tag in pinItem.tags">
-                      <b-button v-bind:key="tag" @click="closeAndGoTo" class="pin-preview-image" type="is-link is-small" :to="{ name: 'tag', params: {tag: tag} }">{{ tag }}</b-button>
+                      <b-button v-bind:key="tag" @click="closeAndGoTo" class="pin-preview-tag" type="is-link is-small" :to="{ name: 'tag', params: {tag: tag} }">{{ tag }}</b-button>
                     </template>
                   </p>
                 </div>

--- a/pinry-spa/src/components/PinPreview.vue
+++ b/pinry-spa/src/components/PinPreview.vue
@@ -120,6 +120,9 @@ export default {
 }
 /* preview size should always less then screen */
 .card-image img {
-  width: 100%;
+  padding: 10px;
+  margin-left: auto;
+  margin-right: auto;
+  width: auto;
 }
 </style>

--- a/pinry-spa/src/components/PinPreview.vue
+++ b/pinry-spa/src/components/PinPreview.vue
@@ -23,7 +23,9 @@
                   <p class="subtitle is-6" v-show="pinItem.tags.length > 0">
                     <span class="subtitle dim">in&nbsp;</span>
                     <template v-for="tag in pinItem.tags">
-                      <b-tag v-bind:key="tag" type="is-info" class="pin-preview-tag">{{ tag }}</b-tag>
+                      <b-tag v-bind:key="tag" type="is-info" class="pin-preview-tag">
+                      <router-link class="pin-preview-tag" :to="{ name: 'tag', params: {tag: tag} }">{{ tag }}</router-link>
+                      </b-tag>
                     </template>
                   </p>
                 </div>
@@ -117,6 +119,7 @@ export default {
 .pin-preview-tag {
   margin-right: 0.2rem;
   margin-bottom: 2px;
+  color: white;
 }
 /* preview size should always less then screen */
 .card-image img {


### PR DESCRIPTION
Fixes #343 by setting the image width to auto, and centering it in the modal window.