### PR TITLE
Don't zoom in on small images in preview window

### DIFF
--- a/pinry-spa/src/components/PinPreview.vue
+++ b/pinry-spa/src/components/PinPreview.vue
@@ -120,6 +120,9 @@ export default {
 }
 /* preview size should always less then screen */
 .card-image img {
-  width: 100%;
+  padding: 10px;
+  margin-left: auto;
+  margin-right: auto;
+  width: auto;
 }
 </style>


### PR DESCRIPTION
Fixes https://github.com/pinry/pinry/issues/343 by setting the image width to auto, and centering it in the modal window.