### PR TITLE
Do not show Source link when no source is defined

### DIFF
--- a/pinry-spa/src/components/Pins.vue
+++ b/pinry-spa/src/components/Pins.vue
@@ -58,7 +58,7 @@
                             </span>
                           </template>
                         </template>
-                        • <a :href="item.referer" target="_blank">{{ $t("sourceLink") }}</a>
+                        <span v-if="item.referer">• <a :href="item.referer" target="_blank">{{ $t("sourceLink") }}</a></span>
                       </span>
                     </div>
                     <div class="is-clearfix"></div>


### PR DESCRIPTION
Hello,

I noticed that "Source" link always shows in a pin description, even if no source is defined.

My change hides the "Source" part when the source/referer is empty.