### PR TITLE
Fix unbound image alt attribute

### DIFF
--- a/pinry-spa/src/components/Pins.vue
+++ b/pinry-spa/src/components/Pins.vue
@@ -31,7 +31,7 @@
                   <img :src="item.url"
                      @load="onPinImageLoaded(item.id)"
                      @click="openPreview(item)"
-                     alt="item.description"
+                     :alt="item.description"
                      :style="item.style"
                      class="pin-preview-image">
                 </div>


### PR DESCRIPTION
Looks like the pin image's alt attribute is meant to come from the item description, but isn't using the bind syntax, so all images have the "item.description" as the alt text currently.